### PR TITLE
Improve debian packaging and fix compatibility

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+libgestures (2.1.14-1ubuntu2) vivid-galliumos; urgency=medium
+
+  * Disable testing
+  * Enable parallel build
+  * Allow dependency on libjsoncpp0v5 for gcc5
+
+ -- Eugene San (eugenesan) <eugenesan@gmail.com>  Fri, 25 Dec 2015 08:10:01 -0500
+
 libgestures (2.1.14-1ubuntu1) vivid-galliumos; urgency=medium
 
   * Improved tap to click fix filter interpreter

--- a/debian/control
+++ b/debian/control
@@ -24,6 +24,6 @@ Description: Development files for libgestures
 Package: libgestures
 Section: libs
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libglib2.0-0, libjsoncpp0
+Depends: ${shlibs:Depends}, ${misc:Depends}, libglib2.0-0, libjsoncpp0 | libjsoncpp0v5
 Description: ChromiumOS libgestures
  Gestures library from chromiumOS.  Required by xf86-input-cmt

--- a/debian/rules
+++ b/debian/rules
@@ -10,4 +10,7 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@ 
+	dh $@ --parallel
+
+override_dh_auto_test:
+	# Disabled


### PR DESCRIPTION
 * Disable testing
 * Enable parallel build
 * Allow dependency on libjsoncpp0v5 for gcc5

(Tested on trusty/wily/xenial)