### PR TITLE
Added cmath import for sqrtf() in finger_metrics.h

### DIFF
--- a/include/gestures/include/finger_metrics.h
+++ b/include/gestures/include/finger_metrics.h
@@ -8,6 +8,7 @@
 #include "gestures/include/gestures.h"
 #include "gestures/include/prop_registry.h"
 #include "gestures/include/vector.h"
+#include <cmath>
 
 namespace gestures {
 


### PR DESCRIPTION
Fixes an issue with sqrtf() not beeing in scope:

`In file included from include/gestures/include/box_filter_interpreter.h:9:0,`
`from src/box_filter_interpreter.cc:5:`
`include/gestures/include/finger_metrics.h: In member function ‘float gestures::Vector2::Mag() const’:`
`include/gestures/include/finger_metrics.h:38:25: error: ‘sqrtf’ was not declared in this scope`
`return sqrtf(MagSq());`
`^`
`make: *** [Makefile:174: obj/box_filter_interpreter.o] Error 1`

Working for me with gcc version 6.2.1 20160830 (Arch Linux)
